### PR TITLE
[Hotfix] Add UCX_TLS environment variable for linux-64 target

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -42,6 +42,9 @@ mkl = ">=2023"
 [target.linux-64.pypi-dependencies]
 pypardiso = ">=0.4"
 
+[target.linux-64.activation.env]
+UCX_TLS = "tcp,self"
+
 ##########################################
 ####### Features dependencies ############
 ##########################################


### PR DESCRIPTION
This pull request adds a new environment variable configuration for Linux-64 builds in the `pixi.toml` file. The main change is the activation of the `UCX_TLS` variable, which specifies the transport layer to use for UCX-based communication.

Environment configuration:

* Added `UCX_TLS = "tcp,self"` to the `[target.linux-64.activation.env]` section in `pixi.toml` to enforce TCP and self transports for UCX communication.