### PR TITLE
Modify sdist exclude patterns for directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,9 +102,9 @@ packages = ["src/voids"]
 
 [tool.hatch.build.targets.sdist]
 exclude = [
-  "examples/data",
-  "notebooks",
-  "docs",
+  "examples/data/**",
+  "notebooks/**",
+  "docs/**",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This pull request makes a small update to the `pyproject.toml` build configuration. The change ensures that the entire contents of the `examples/data`, `notebooks`, and `docs` directories (including all subdirectories and files) are excluded from source distributions, rather than just the top-level directories.
